### PR TITLE
Add support for building for 64 bit Windows

### DIFF
--- a/src/SOIL.c
+++ b/src/SOIL.c
@@ -15,7 +15,12 @@
 
 #define SOIL_CHECK_FOR_GL_ERRORS 0
 
-#ifdef WIN32
+#ifdef _WIN64
+	#define WIN64_LEAN_AND_MEAN
+	#include <windows.h>
+	#include <wingdi.h>
+	#include <GL/gl.h>
+#elif defined _WIN32
 	#define WIN32_LEAN_AND_MEAN
 	#include <windows.h>
 	#include <wingdi.h>


### PR DESCRIPTION
Fairly simple change to enable building SOIL for Windows 64, tested with Visual Studio 2013. The _WIN32 seems to be defined for both 32 and 64 bit platforms, so I put the check for _WIN64 first.
