### PR TITLE
Fixed build issue when GL_ES_VERSION_2_0 is defined

### DIFF
--- a/src/SOIL.c
+++ b/src/SOIL.c
@@ -1943,10 +1943,10 @@ int query_cubemap_capability( void )
 		&&
 			(NULL == strstr( (char const*)glGetString( GL_EXTENSIONS ),
 				"GL_EXT_texture_cube_map" ) )
-			)
 		#ifdef GL_ES_VERSION_2_0
-		&& (false) /* GL ES 2.0 supports cubemaps, always enable */
+		&& (0) /* GL ES 2.0 supports cubemaps, always enable */
 		#endif
+			)
 		{
 			/*	not there, flag the failure	*/
 			has_cubemap_capability = SOIL_CAPABILITY_NONE;


### PR DESCRIPTION
It appears that I introduced this issue in 4fd65af914ac33ebf39fa25278733a936a14d50d, but I'm pretty sure it built ok at the time... I must have done something wrong during the build test or merge.

At any rate, the #ifdef has to be inside the if(), otherwise it throws a syntax error. Also, false is not defined in plain C, so I replaced it with 0.