### PR TITLE
Fix CXX and CXXFLAGS are for g++ and this is a C project #18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,7 @@ LIBDIR = lib
 INCDIR = src
 OBJDIR = obj
 
-CXX = gcc
-CXXFLAGS = -O2 -s -Wall
+CFLAGS ?= -O2 -s -Wall
 DELETER = rm -f
 COPIER = cp
 
@@ -39,7 +38,7 @@ $(BIN): $(OBJ)
 
 $(OBJDIR)/%.o: $(SRCDIR)/%.c
 	mkdir -p $(OBJDIR)
-	$(CXX) $(CXXFLAGS) -o $@ -c $<
+	$(CC) $(CFLAGS) -o $@ -c $<
 
 
 clean:


### PR DESCRIPTION
CXX = gcc is not a good idea because:
1/ We cannot override options like: make CC=clang-13 CFLAGS="-O2 -s -Wall -fPIC" -j8
2/ CXX is for g++ and overriding will fail compiling the project. 3/ CC is by default equals to cc (gcc)
3/ CC is by default equals to cc (gcc)